### PR TITLE
feat: Update agreement properties for improved search conditions and increment package version to 0.1.17

### DIFF
--- a/nodes/ConnectWiseManage/properties/agreementProperties.ts
+++ b/nodes/ConnectWiseManage/properties/agreementProperties.ts
@@ -80,8 +80,8 @@ export const agreementProperties: INodeProperties[] = [
 		description: 'The name of the agreement',
 	},
 	{
-		displayName: 'Search Query',
-		name: 'searchQuery',
+		displayName: 'Conditions',
+		name: 'conditions',
 		type: 'string' as NodePropertyTypes,
 		default: '',
 		required: true,
@@ -91,7 +91,8 @@ export const agreementProperties: INodeProperties[] = [
 				operation: ['search'],
 			},
 		},
-		description: 'Search query to filter agreements',
+		description:
+			'Query conditions to filter agreements (e.g., "name like \'Test%\'" or "type=\'Standard\'")',
 	},
 	{
 		displayName: 'Return All',
@@ -100,7 +101,7 @@ export const agreementProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['agreement'],
-				operation: ['getAll'],
+				operation: ['getAll', 'search'],
 			},
 		},
 		default: false,
@@ -113,7 +114,7 @@ export const agreementProperties: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['agreement'],
-				operation: ['getAll'],
+				operation: ['getAll', 'search'],
 				returnAll: [false],
 			},
 		},
@@ -122,19 +123,6 @@ export const agreementProperties: INodeProperties[] = [
 		},
 		default: 100,
 		description: 'Max number of results to return',
-	},
-	{
-		displayName: 'Order By',
-		name: 'orderBy',
-		type: 'string' as NodePropertyTypes,
-		default: 'id',
-		displayOptions: {
-			show: {
-				resource: ['agreement'],
-				operation: ['getAll', 'search'],
-			},
-		},
-		description: 'Order results by specified field',
 	},
 	{
 		displayName: 'Additional Fields',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adamhancock/n8n-nodes-msp-ai",
-	"version": "0.1.16",
+	"version": "0.1.17",
 	"description": "Custom n8n nodes for MSPs",
 	"keywords": [
 		"n8n-community-node-package"


### PR DESCRIPTION
This pull request updates the `agreementProperties` in the `ConnectWiseManage` node and includes a version bump in the `package.json` file. The most important changes involve renaming and enhancing filtering options, extending operations, and removing unused properties for simplicity.

### Updates to `agreementProperties`:

* Renamed the `searchQuery` property to `conditions` and updated its description to allow more expressive query conditions for filtering agreements (e.g., "name like 'Test%'" or "type='Standard'"). (`nodes/ConnectWiseManage/properties/agreementProperties.ts`, [[1]](diffhunk://#diff-1a62a9f69d90561c3d7259fb8ec0bd22cfc4fbdcc44f42f79fd2e6280064e675L83-R84) [[2]](diffhunk://#diff-1a62a9f69d90561c3d7259fb8ec0bd22cfc4fbdcc44f42f79fd2e6280064e675L94-R95)
* Added support for the `search` operation in properties that were previously limited to `getAll`, such as `Return All` and `Limit`. (`nodes/ConnectWiseManage/properties/agreementProperties.ts`, [[1]](diffhunk://#diff-1a62a9f69d90561c3d7259fb8ec0bd22cfc4fbdcc44f42f79fd2e6280064e675L103-R104) [[2]](diffhunk://#diff-1a62a9f69d90561c3d7259fb8ec0bd22cfc4fbdcc44f42f79fd2e6280064e675L116-R117)
* Removed the `Order By` property, simplifying the configuration by eliminating unused or unnecessary fields. (`nodes/ConnectWiseManage/properties/agreementProperties.ts`, [nodes/ConnectWiseManage/properties/agreementProperties.tsL126-L138](diffhunk://#diff-1a62a9f69d90561c3d7259fb8ec0bd22cfc4fbdcc44f42f79fd2e6280064e675L126-L138))

### Version bump:

* Updated the package version from `0.1.16` to `0.1.17` in `package.json` to reflect the changes. (`package.json`, [package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3))