### PR TITLE
Resolved malformed body updated requirements

### DIFF
--- a/nodes/ConnectWiseManage/properties/ticketProperties.ts
+++ b/nodes/ConnectWiseManage/properties/ticketProperties.ts
@@ -241,6 +241,20 @@ export const ticketProperties: INodeProperties[] = [
 		},
 		description: 'The summary of the ticket',
 	},
+	{
+		displayName: 'Company ID',
+		name: 'company',
+		type: 'number' as NodePropertyTypes,
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['ticket'],
+				operation: ['create'],
+			},
+		},
+		description: 'The ID of the company associated with the ticket',
+	},
 	// Fields for addNote
 	{
 		displayName: 'Note Text',


### PR DESCRIPTION
Resolved the malformed body when creating tickets

For example, it was passing the company ID like so:
```json
{ "company": "22" }
```
but according to the API it should be like:
```json
{ "company": { "id": 22 } }
```

Additionally, according to the API, company ID is a required field alongside summary. 

This solves the issue #9 